### PR TITLE
Dedupe rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,6 @@ rules:
   no-negated-in-lhs: 2
   no-obj-calls: 2
   no-regex-spaces: 2
-  no-regex-spaces: 2
   no-reserved-keys: 0
   no-sparse-arrays: 2
   no-unreachable: 2
@@ -166,7 +165,6 @@ rules:
   newline-after-var:
     - 2
     - always
-  new-parens: 2
   no-array-constructor: 2
   no-continue: 0
   no-inline-comments: 0
@@ -199,11 +197,9 @@ rules:
   quote-props:
     - 2
     - as-needed
-  padded-blocks: 0
   quotes:
     - 2
     - single
-  padded-blocks: 0
   semi-spacing:
     - 2
     -
@@ -224,7 +220,6 @@ rules:
   space-in-parens:
     - 2
     - never
-  space-infix-ops: 2
   space-return-throw-case: 2
   space-unary-ops: 2
   spaced-comment:


### PR DESCRIPTION
J'ai juste retiré quelques doublons.

Le one-liner qui va bien sous vim :

```
:syn clear Repeat | g/^\(.*\)\n\ze\%(.*\n\)*\1$/exe 'syn match Repeat "^' . escape(getline('.'), '".\^$*[]') . '$"' | nohlsearch
```
