### PR TITLE
[Chore] Pin dependency eslint to version 3.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "simplifield"
   ],
   "devDependencies": {
-    "eslint": "^3.13.0",
+    "eslint": "3.14.1",
     "mocha": "3.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This Pull Request update dependency eslint from version ^3.13.0 to 3.14.1

